### PR TITLE
chore: set cache-control to max 31536000 instead of 604800

### DIFF
--- a/src/netlify_files/netlify.toml
+++ b/src/netlify_files/netlify.toml
@@ -1,8 +1,8 @@
 [[headers]]
   for = "/js/*.js" # js files should be set this way
   [headers.values]
-    Cache-Control = "public, max-age=604800"
+    Cache-Control = "public, max-age=31536000"
 [[headers]]
   for = "*.css" # css files too
   [headers.values]
-    Cache-Control = "public, max-age=604800"
+    Cache-Control = "public, max-age=31536000"


### PR DESCRIPTION
 to serve static assets with an efficient cache policy